### PR TITLE
add Current to IProgressBar

### DIFF
--- a/Goblinfactory.ProgressBar/IProgressBar.cs
+++ b/Goblinfactory.ProgressBar/IProgressBar.cs
@@ -5,11 +5,10 @@
         string Line1 { get; }
         string Line2 { get; }
         int Y { get; }
+        int Current { get; }
         int Max { get; set; }
         void Refresh(int current, string item);
         void Refresh(int current, string format, params object[] args);
         void Next(string item);
     }
-
-
 }

--- a/Goblinfactory.ProgressBar/ProgressBar.cs
+++ b/Goblinfactory.ProgressBar/ProgressBar.cs
@@ -4,9 +4,10 @@ namespace Konsole
     public enum PbStyle {  SingleLine, DoubleLine }
     public class ProgressBar : IProgressBar
     {
-        private IProgressBar _bar;
+        private readonly IProgressBar _bar;
 
         public int Y => _bar.Y;
+        public int Current => _bar.Current;
         public string Line1 => _bar.Line1; 
         public string Line2 => _bar.Line2;
 

--- a/Goblinfactory.ProgressBar/ProgressBarTwoLine.cs
+++ b/Goblinfactory.ProgressBar/ProgressBarTwoLine.cs
@@ -18,6 +18,8 @@ namespace Konsole
             get { return _y; }
         }
 
+        public int Current => _current;
+
         public string Line1
         {
             get { return _line1; }


### PR DESCRIPTION
Added a public get-only property `Current` for `IProgressBar` which exposes the current progress of the `ProgressBar` class.